### PR TITLE
Version 2.0

### DIFF
--- a/test.js
+++ b/test.js
@@ -614,3 +614,67 @@ test('internal mixin method test', function(t) {
   );
   create().foo();
 });
+
+test('autobinding test', function(t) {
+  return new Promise(function(resolve) {
+    var create = mixinable({
+      foo: mixinable.override,
+      bar: mixinable.override,
+    })({
+      foo: function() {
+        t.pass('first method is being called directly');
+        t.truthy(
+          this.constructor.prototype.foo.hasOwnProperty('prototype'),
+          'first mixin prototype method is unbound'
+        );
+        t.falsy(
+          this.foo.hasOwnProperty('prototype'),
+          'first mixin method is bound'
+        );
+        setTimeout(this.bar, 5);
+      },
+      bar: function() {
+        t.pass('second method is being called indirectly');
+        t.truthy(
+          this.constructor.prototype.bar.hasOwnProperty('prototype'),
+          'second mixin prototype method is unbound'
+        );
+        t.falsy(
+          this.bar.hasOwnProperty('prototype'),
+          'second mixin method is bound'
+        );
+        setTimeout(this.baz, 5);
+      },
+      baz: function() {
+        t.pass('third method is being called indirectly');
+        t.truthy(
+          this.constructor.prototype.baz.hasOwnProperty('prototype'),
+          'third mixin prototype method is unbound'
+        );
+        t.falsy(
+          this.baz.hasOwnProperty('prototype'),
+          'third mixin method is bound'
+        );
+        setTimeout(this.qux, 5);
+      },
+      qux: function() {
+        t.pass('fourth method is being called indirectly');
+        t.truthy(
+          this.constructor.prototype.qux.hasOwnProperty('prototype'),
+          'fourth mixin prototype method is unbound'
+        );
+        t.falsy(
+          this.qux.hasOwnProperty('prototype'),
+          'fourth mixin method is bound'
+        );
+        resolve();
+      },
+    });
+    var instance = create();
+    t.falsy(
+      instance.foo.hasOwnProperty('prototype'),
+      'mixinable method is bound'
+    );
+    instance.foo();
+  });
+});

--- a/test.js
+++ b/test.js
@@ -593,3 +593,24 @@ test('clone function test', function(t) {
   var clone = mixinable.clone(instance, arg2);
   t.is(clone.foo(), arg1 + arg2, 'clone returns expected value');
 });
+
+test('internal mixin method test', function(t) {
+  t.plan(2);
+  var create = mixinable({
+    foo: mixinable.override,
+    bar: mixinable.override,
+  })(
+    {
+      foo: function() {
+        t.pass('first method is being called directly');
+        this.bar();
+      },
+    },
+    {
+      bar: function() {
+        t.pass('second method is being called indirectly');
+      },
+    }
+  );
+  create().foo();
+});


### PR DESCRIPTION
With this PR, we are preparing for release 2.0. In it, I propose to add two new features:

* **autobinding** all mixinable and mixin methods will now automatically be bound to their respective instance for convenience and robustness

* **method availability** you can now call all mixinable methods on every mixin, too - but you will no longer be able to call mixin methods directly, not even from the instance they are defined within