### PR TITLE
Introduce `callable`

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ foo.bar();
 
 `override` returns a `Promise` if one of its implementations does. If you want it to always return a `Promise`, i.e. if you can not be sure whether one of your implementations might return one, please use `define.async.override`.
 
+`override` is aliased to `callable` in all places, enabling implementers to communicate their intentions more clearly as `override` is often used to provide callable (utility) methods.
+
 #### `define.parallel`
 
 `parallel` is a helper implementating a mixin strategy that executes all defined implementations in parallel. This is probably most useful if asynchronous implementations are involved.
@@ -282,11 +284,11 @@ foo.bar(1);
 
 ##### `define.async`
 
-All of the strategies described above return a `Promise` if one of their implementations does. If you want them to always return a `Promise` please use `define.async.{override,parallel,pipe,compose}`.
+All of the strategies described above return a `Promise` if one of their implementations does. If you want them to always return a `Promise` please use `define.async.{override/callable,parallel,pipe,compose}`.
 
 ##### `define.sync`
 
-If you want to make sure one of the strategies never returns a `Promise` please use `define.sync.{override,parallel/sequence,pipe,compose}`. If you do, an `Error` will be thrown if a `Promise` is returned.
+If you want to make sure one of the strategies never returns a `Promise` please use `define.sync.{override/callable,parallel/sequence,pipe,compose}`. If you do, an `Error` will be thrown if a `Promise` is returned.
 
 ### Contributing
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = exports = function define(strategies) {
 
 // strategy exports
 
-exports.override = function override(functions) {
+exports.callable = exports.override = function override(functions) {
   var args = argsToArray(arguments).slice(1);
   var fn = functions.slice().pop();
   if (isFunction(fn)) {
@@ -46,6 +46,7 @@ exports.compose = function compose(functions) {
 };
 
 exports.async = {
+  callable: asynchronize(exports.callable),
   override: asynchronize(exports.override),
   parallel: asynchronize(exports.parallel),
   pipe: asynchronize(exports.pipe),
@@ -53,6 +54,7 @@ exports.async = {
 };
 
 exports.sync = {
+  callable: asynchronize(exports.callable),
   override: synchronize(exports.override),
   sequence: synchronize(exports.parallel),
   parallel: synchronize(exports.parallel),

--- a/test.js
+++ b/test.js
@@ -7,16 +7,19 @@ var async = mixinable.async;
 var sync = mixinable.sync;
 
 test('exports test', function(t) {
-  t.plan(14);
+  t.plan(17);
   t.is(typeof mixinable, 'function', 'main export is a function');
+  t.is(typeof mixinable.callable, 'function', 'callable is a function');
   t.is(typeof mixinable.override, 'function', 'override is a function');
   t.is(typeof mixinable.parallel, 'function', 'parallel is a function');
   t.is(typeof mixinable.pipe, 'function', 'pipe is a function');
   t.is(typeof mixinable.compose, 'function', 'compose is a function');
+  t.is(typeof async.callable, 'function', 'async.callable is a function');
   t.is(typeof async.override, 'function', 'async.override is a function');
   t.is(typeof async.parallel, 'function', 'async.parallel is a function');
   t.is(typeof async.pipe, 'function', 'async.pipe is a function');
   t.is(typeof async.compose, 'function', 'async.compose is a function');
+  t.is(typeof sync.callable, 'function', 'sync.callable is a function');
   t.is(typeof sync.override, 'function', 'sync.override is a function');
   t.is(typeof sync.parallel, 'function', 'sync.parallel is a function');
   t.is(typeof sync.pipe, 'function', 'sync.pipe is a function');
@@ -109,6 +112,32 @@ test('inheritance test', function(t) {
     },
   };
   var instance = mixinable(Strategy)(Implementation)(arg);
+  instance.foo(arg);
+});
+
+test('callable helper test', function(t) {
+  t.plan(2);
+  var arg = 1;
+  var instance = mixinable({
+    foo: mixinable.callable,
+  })(
+    {
+      foo: function() {
+        t.fail('1st implementation should not be called');
+      },
+    },
+    {
+      foo: function() {
+        t.fail('2nd implementation should not be called');
+      },
+    },
+    {
+      foo: function(_arg) {
+        t.pass('3rd implementation is being called');
+        t.is(_arg, arg, '3rd implementation receives correct arg');
+      },
+    }
+  )();
   instance.foo(arg);
 });
 


### PR DESCRIPTION
`callable` is just an alias to the different `override` variants. It is meant to communicate an implementer's intention better than the generic `override`.

Closes #42